### PR TITLE
Add External Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@
 /*.tar*
 /*.bin
 /*.log
-
+/config.sh

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+#	Set default configuration values
+#	These can be overridden by entering them into config.sh
 ALARM_MIRROR="http://de.mirror.archlinuxarm.org"
 
 QEMU_AARCH64="https://github.com/multiarch/qemu-user-static/releases/download/v7.2.0-1/qemu-aarch64-static.tar.gz"
@@ -30,6 +32,12 @@ TIMEZONE="Europe/Paris"              # Timezone
 USERNAME="user"
 USERPWD="admin"
 ROOTPWD="admin"                      # Root password
+
+#	Check if 'config.sh' exists.  If so, source that to override default values.
+if [ -f "config.sh" ]; then
+	source config.sh
+fi
+
 
 function setupenv {
 #BACKUPFILE="/run/media/$USER/DATA/${target}-${atfdevice}-rootfs.tar"

--- a/config.example.sh
+++ b/config.example.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#	This file is an example showing how to override configuration values.  Set
+#	appropriate values and rename to 'config.sh'
+#
+#	Any values that are not set here will use default values when build.sh is
+#	run.
+
+
+#	Add a few additional packages to the build.
+#NEEDED_PACKAGES="base hostapd openssh wireless-regdb iproute2 nftables f2fs-tools dosfstools"
+#NEEDED_PACKAGES+=' '"dtc mkinitcpio patch sudo evtest parted"
+NEEDED_PACKAGES+=' '"tcpdump nmap traceroute"
+
+#	Override the timezone
+TIMEZONE="America/Los_Angeles"
+
+#	Override the default username and password
+USERNAME="brian"
+USERPWD="Password123"
+
+#	Override the default root password
+ROOTPWD="SuperSecretPassword"


### PR DESCRIPTION
### Description

This pull request allows the use of an external configuration file for the build script's variables.  After building several test images for the Banana Pi BPI-R3, it became apparent that I consistently installed additional packages, changed the timezone, and had to reset the default password.  By sourcing an external config script, end users are able to have their own configuration while still falling back to default values.

This change includes:

- Checking for the existence of '**config.sh**' and sourcing the file if it exists.
- Adding '**/config.sh**' to the **.gitignore** file.
- Adding '**config.example.sh**' to demonstrate various ways that default values can be overridden.

### Code Changes

The code changes in this pull request are exceedingly simple.  There is an added check for the existence of '**config.sh**', which if exists, is sourced.  This is done after default values are set, so readability is not impaired, and anything not defined in '**config.sh**' is still set with a sane default.

